### PR TITLE
Add scenario text splits

### DIFF
--- a/Diagnosis scenarios/asha_r.txt
+++ b/Diagnosis scenarios/asha_r.txt
@@ -1,0 +1,27 @@
+Collated Documents: "Asha R." (Year 12, age 18)
+1. Private journal extract -3 August
+1.05 am: I swear Mum will ditch me like Dad did. She rolled her eyes at dinner when I spilled smoothie on my uniform. I wanted to smash the glass just to watch it shatter.
+1.42 am: Texted Lucas six times, no reply. Heart racing. Does silence mean he is bored already? Thought about that razor in the bathroom. Scratched my thigh instead, felt calmer for a minute.
+2.10 am: Whole body suddenly buzzing. New plan: graduate, move to Melbourne, start a street-fashion label. I can do this. I just need investors and 10 000 followers. Easy.
+2. Parent email to Year-Level Coordinator -9 August
+Asha is brilliant but exhausting. One night she is designing clothes till 3 am, next morning she will not get out of bed, says life is pointless. Last week she spent $420 from her savings on fabric, then begged me to cover her phone bill. She alternates between hugging me and screaming I "never listen". History: her father left when she was ten. We have no family history of bipolar but my sister has depression.
+3. School office incident log -18 August
+Student arrived late with heavy eye make-up smudged. Argued with attendance officer, stating "rules are fake anyway". When reminded about uniform skirt length, burst into tears and said "Everyone hates me". Calmed after ten minutes, apologised, and offered to run errands for staff.
+4. English teacher comment -Term 3 progress
+ Insightful writer, especially on themes of betrayal and identity.
+ Assessment pattern: drafts appear overnight in long, emotional bursts; otherwise misses deadlines entirely.
+ Class interaction oscillates between dominating discussion and silent withdrawal.
+5. School counsellor note -25 August
+Rapport established quickly; student animated and humorous. Describes "intense" friendships that "burn out". Reports cutting forearm with safety pin once in June, multiple superficial scratches since. Says she feels "empty" when alone yet pushes people away to "test if they stay". Mood shifts hourly, triggered by perceived rejection. Denies full suicide plan but admits "sometimes driving into a pole seems easier". Eating erratic: coffee for breakfast, binge on chips after school, then guilt.
+6. GP visit summaries (key points)
+ May -Presents with abdominal cramps; tests normal. GP suspects stress; recommends mindfulness app.
+ July -Reports insomnia and "racing ideas" for fashion brand. PHQ-9 score 11 (moderate). GP queries hypomania, asks to keep sleep-mood diary.
+ 28 August -Sleep diary shows 3 - 5 h nights alternating with 10 h "crash" days. Cutting episodes noted. GP flags possible personality disorder, refers for dialectical behaviour therapy program; SSRIs discussed but deferred due to mood lability.
+7. Group-chat snippet -1 September
+Asha: Lucas liked Abby's pic. Guess he wants her now. Whatever, I'm deleting Insta.
+Friend: It was just a like. Chill.
+Asha: I'm DONE being second choice. Might drop formal and move to the coast tonight.
+Friend: You okay?
+Asha: Never better. Starting fresh. Watch me blow up.
+8. Retail bank alert -4 September
+SMS notice: "Your account balance is below $10. Last transaction $189.95 -Boutique Cosmetics Online."

--- a/Diagnosis scenarios/callum_h.txt
+++ b/Diagnosis scenarios/callum_h.txt
@@ -1,0 +1,45 @@
+Collated Documents: "Callum H." (Year 12, age 17)
+1. Personal journal entry  -  14 April
+12.21 am  -  Scored two hundred bucks flipping "limited" sneakers at lunch. Teachers are clueless. Easy win.
+12.40 am  -  Courtside seats someday, front row, everyone wanting my autograph. They will beg for tips.
+1.03 am  -  Dad harped about "ethics". Joke. If you are smart enough to bend rules, you deserve the prize.
+1.28 am  -  Need new thrill. Maybe drone dash through the mall roof gap? Would go viral. Risk equals followers, equals sponsors.
+2. Parent email to Year-Level Coordinator  -  19 April
+Callum was suspended last term for hacking the canteen payment system. We covered the damages, but he shrugged it off. Last night a neighbour accused him of stealing power tools; he laughed and said, "Prove it." He comes home with cash yet refuses to explain where it comes from. Younger brother avoids him after Callum pinned him for "wasting my phone charger". Family history: father had two juvenile theft charges, later clean. No diagnosed mental illness in close relatives.
+3. Semester Progress Snapshot
+                                    Subject
+                           Teacher comment (excerpt)
+Information & Digital Tech
+"Top coder, but shared cheat scripts with classmates for money. Shows no remorse when confronted."
+Business
+"Talks over peers, boasting he will `own half the class one day'. Ignores group roles, claims final credit."
+English
+"Writes slick persuasive pieces yet plagiarised an entire paragraph, said originality rules `don't apply in real biz'."
+PE  -  Rugby
+"Athletic captain, but taunts opponents, once elbowed a winger after whistle. Dismissed it as `mental edge'."
+Unexplained absences: 6 single periods  -  often return with food from nearby shopping centre.
+
+4. School counsellor note  -  26 April
+Charming, maintains eye contact, cracks jokes. Denies guilt: "Systems are there to beat." Scores high on sensation-seeking inventory. Admits three late-night street races on motorbike ("only fun if cops might show"). Says friends "respect a winner" and "weaklings deserve to lose". No genuine distress. Smirks when asked about empathy.
+
+5. GP visit summaries
+                                     Date
+                               Reason / Findings
+                                     Plan
+10 March
+Cut knuckles after punch-up at skate park. Blames "idiot who stepped up". Vitals normal.
+Stressed road safety, offered counselling; declined.
+27 April
+Mild concussion from bike crash (no helmet). Laughs off risk.
+CT clear. Brief advice on impulsivity, referred to youth mental-health clinic; yet to book.
+
+6. Community police youth-diversion report  -  3 May
+"Callum and two peers found inside disused warehouse at 23 40 h with spray cans and bolt cutters. Claim they were filming `urban exploration content'. Minor property damage ($600) and trespass. Cautioned; parents collected. Callum joked about starting a merch line with warehouse logo."
+
+7. Work-experience supervisor feedback  -  15 May
+At automotive workshop:
+ Impressive mechanical skills, but repeatedly borrowed cash from co-workers promising repayment "when crypto pumps".
+ Ignored safety brief, removed guard from angle grinder for "speed".
+ Bragged he could "run this joint better by twenty-one".
+
+

--- a/Diagnosis scenarios/ethan_s.txt
+++ b/Diagnosis scenarios/ethan_s.txt
@@ -1,0 +1,67 @@
+Collated Documents: "Ethan S." (Year 11, age 17)
+1. Private diary extract -6 March
+1.18 am -Been staring at blank Word screen two hours. Every sentence looks stupid. Might as well hand in nothing.
+1.54 am -Mum keeps knocking, says lights need to be off. Can't sleep anyway - mind loops on what happens if I fail Chem, if Dad's job goes, if dog gets sick.
+2.27 am -Thought about messaging Logan but what's the point? He'll just say "cheer up". Imagined crash-tackling the clock so it quits ticking.
+Goal: make it to school without vomiting from nerves.
+
+2. Parent email to Year-Level Co-ordinator -10 March
+Ethan is missing the bus three mornings a week -says he "feels heavy". He leaves half his dinner, claims no appetite, yet snacks on dry crackers at 2 am. Weight down four kilos since January. He's stopped footy training despite physio clearing his ankle sprain. Spends weekends in bed scrolling job-loss articles. Our family has an anxiety streak (my father had "nerves"), but Ethan's never been this flat.
+
+3. Term 1 Progress Snapshot
+                                    Subject
+                           Teacher comment (excerpt)
+Chemistry
+"Previously inquisitive; now silent, head on desk, missed practical write-up."
+English
+"Draft handed in late, apologised profusely, crossed out whole paragraphs in red saying `not good enough'."
+Maths Methods
+"Marks dropped from 88 % to 62 %. Requests extra practice tests but does not complete them."
+Health & PE
+"Cleared for sport but refuses sprints, says legs feel like concrete."
+Attendance: 3 full days and 5 single periods absent since mid-February ("migraine", "upset stomach").
+
+4. School counsellor intake -22 March
+Arrived ten minutes early, hunched posture, tearful when describing "letting everyone down". Reports low mood "pretty much every day", morning dread, concentration fog, and feeling "hollow". Worries about family finances and climate disasters but says these thoughts "just confirm how pointless things are". No manic history. Passive thought: "If I didn't wake up, that'd solve it", no plan or intent. Still enjoys coding playlist mixes when energy allows.
+
+
+
+Collated Documents: "Ethan S." (Year 11, age 17)                                             (page)
+
+5. GP visit summaries
+                                     Date
+                              Concerns / Findings
+                                     Plan
+31 January
+Ongoing fatigue, difficulty staying asleep, loss of appetite. Vitals normal.
+Suggested bloods (all normal) and sleep-hygiene handout.
+2 March
+Persistent sadness, anhedonia, guilt, poor concentration. PHQ-9 = 19 (moderate-severe).
+Referral for CBT; discussed SSRI if no improvement in 4 - 6 weeks.
+28 March
+Anxiety rumination (GAD-7 = 13) plus unchanged low mood. No self-harm plan.
+CBT commenced; review medication option at next consult.
+
+6. Footy-coach note -4 April
+"Ethan attended training, jogged half warm-up then sat by fence. Said `legs feel dead, not worth risking'. Teammates invited him to strategy chat; he shrugged and left early, head down."
+
+7. Social-media DM exchange -8 April
+Logan: Bro big LAN party Friday, keen?
+Ethan: Maybe another time, assignments piling.
+Logan: We'll game after homework.
+Ethan: I'll just slow things down -hardly awake lately.
+Logan: You good?
+Ethan: All sweet, just tired.
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Diagnosis scenarios/noah_l.txt
+++ b/Diagnosis scenarios/noah_l.txt
@@ -1,0 +1,68 @@
+Collated Documents: "Noah L." (Year 11, age 16)
+1. Private diary extract -7 May
+11.18 pm -Tried to sleep but my heart thumps every time I list the things that could go wrong tomorrow: Chem prac blow-up? Dad's ute break down? Storm flood the creek?
+11.53 pm -Googled "teen heart attack risk" for the fifth night running. Still says rare but what if I'm the stat?
+12.26 am -Made a checklist for breathing drills. Mum says stop setting alarms at midnight, but I need the reminder or I'll forget and something bad will happen.
+
+2. Parent email to Year-Level Coordinator -12 May
+Noah keeps asking if we've paid the electricity bill and whether Dad's hours will be cut. He double-locks every window before school "in case of break-ins". Eats dinner standing up, says sitting feels "too slow". He's been getting tension headaches and complains his stomach "twists" on the bus. Family history: my sister has an anxiety disorder; Noah's grandfather had chronic worry but was never diagnosed.
+
+3. Semester Progress Snapshot
+                                    Subject
+                           Teacher comment (excerpt)
+Maths Methods
+"Scores high but requests extra tutorials, fearing a `surprise topic'."
+English
+"Drafts three versions of every essay; perfectionism delays submission."
+Biology
+"Frequently checks mark scheme mid-experiment; appears restless, taps foot."
+Physical Education
+"Dropped out of cross-country, citing chest tightness; medical clearance was normal."
+Unexplained absences: 4 half-days since start of term ("migraine" or "nausea").
+
+4. School counsellor intake note -26 May
+Presents neat but fidgety (picks at sleeve hem). Reports "mind never shuts up", worries about academic failure, parents' finances, global warming and little sister crossing the road. Muscle tension in shoulders, nightly difficulty falling asleep (> 60 min latency), wakes unrefreshed. Denies panic attacks, hallucinations, or self-harm thoughts. Low mood "some mornings" when tired, but still enjoys coding club.
+
+
+
+
+
+Collated Documents: "Noah L." (Year 11, age 16)
+(page 2)
+5. GP visit summaries
+                                     Date
+                              Concerns / Findings
+                                     Plan
+3 April
+Headaches, stomach-ache, disturbed sleep. Vitals normal.
+Recommended sleep hygiene, progressive-muscle relaxation app.
+29 April
+Persistent somatic symptoms + worry across school, family, health. GAD-7 = 17 (moderate-severe).
+Suggested CBT referral; discussed trial of SSRI if no response in 6 weeks.
+24 May
+Mild low mood, but motivation intact for coding club. PHQ-9 = 8 (mild).
+Proceed with CBT; monitor mood for possible MDD.
+
+6. Coding-club chat snippet -2 June
+Friend: Dude you crushed the hackathon, relax.
+Noah: What if regional finals add crypto modules? I'll bomb.
+Friend: We'll adapt.
+Noah: Not good enough. Need to start a new codebase tonight... might skip school tomorrow to finish.
+
+7. Bus-driver incident report -8 June
+Passenger (Noah) asked driver three times if brakes "felt normal". Sat near front gripping backpack straps, breathing shallowly. Alighted early when roadworks siren sounded.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Diagnosis scenarios/olivia_k.txt
+++ b/Diagnosis scenarios/olivia_k.txt
@@ -1,0 +1,66 @@
+Collated Documents: "Olivia K." (Year 11, age 16)
+1. Private diary extract -16 July
+11.02 pm -Tomorrow = English oral. Already feel my throat closing. If I freeze everyone will stream it on Snap.
+11.38 pm -Checked YouTube for "people fainting during speeches" (17 videos). Why do they all shake? Heart races watching.
+12.07 am -Practised intro twice in mirror but face went blotchy. Mum says that's "just nerves" -what if it's a sign I'll pass out?
+Goal: survive five minutes without fleeing.
+
+2. Parent email to Year-Level Coordinator -18 July
+Olivia begged to stay home on speech day, said her "stomach was flipping". We compromised: she went in late after panadol, but texted me from the car park crying. She studies hard yet dreads any situation where classmates look at her -birthdays, sport, even ordering at cafés. At family barbecues she sits in our bedroom. She still worries about bushfires and interest rates too, so is it broader anxiety?
+Family: paternal aunt has "high anxiety"; no other mental-health diagnoses.
+
+3. Semester 2 Progress Snapshot
+                                    Subject
+                           Teacher comment (excerpt)
+English
+"Exceptional written analysis. Oral presentations repeatedly deferred; when forced, voice trembles, flushes, avoids eye contact."
+Maths
+"Asks to email questions rather than speak in tutorial."
+Drama (elective)
+Withdrawn from unit in Week 3 after onstage warm-up triggered nausea.
+Health & PE
+"Refuses captain role; claims `others will laugh at my instructions'."
+Attendance: Four single-period absences on days with assessed orals; otherwise punctual.
+
+4. School counsellor intake -2 August
+Polite, softly spoken. Sits near door, fiddles with sleeve. Reports episodes of "panic" when required to read aloud or eat in canteen. Physical signs: rapid pulse, sweating, shaky hands. Worry peaks hours/days beforehand; relief once situation passes. Denies panic attacks in non-social contexts. General worry about future jobs and climate "but no physical symptoms then". Enjoys coding at home, gaming online where "nobody sees my face". Mood generally "okay"; denies self-harm or substance use.
+
+
+Collated Documents: "Olivia K." (Year 11, age 16)                                                        (Page 2)
+5. GP visit summaries
+                                     Date
+                              Concerns / Findings
+                                     Plan
+4 May
+Nausea and dizziness before school speech. No cardiac/vestibular issues.
+Suggested slow-breathing techniques.
+10 June
+Persistent anticipatory worry; two near-faint episodes in class readings (BP 110/70). GAD-7 = 13 (moderate).
+Discussed CBT; referral to psychologist.
+5 August
+Continued avoidance; missed friend's 17th birthday dinner. PHQ-9 = 6 (mild). Sleep fine except before speeches.
+Started CBT-SAD programme; consider SSRI if severe impairment persists.
+
+6. WhatsApp chat -9 August
+Friend: Movie night Sat?
+Olivia: Maybe next time, throat still scratchy.
+Friend: We can get honey tea.
+Olivia: Honestly watching at home is easier. My laugh sounds weird IRL.
+Friend: You know we don't care, right?
+Olivia: Exactly. You should, which makes it worse.
+
+7. Debate-club coach log -15 August
+"Olivia offered sophisticated argumentative points via Google Doc but declined to present them. Became visibly shaky when asked to rebut; apologised, left room to vomit, returned saying `it's the lights'."
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/Diagnosis scenarios/sam_d.txt
+++ b/Diagnosis scenarios/sam_d.txt
@@ -1,0 +1,36 @@
+Collated Documents: "Sam D." (Year 12, age 17)
+1. Personal diary extract : 28 August
+2 am: Wide awake again. Street-light outside keeps pulsing : feels like Morse code? Tried to sketch the pattern but graphite snapped twice. Maybe message isn't for me.
+2.35 am: Thought I heard someone call my name from the hallway. Checked - empty. Could have been wind or Cooper sleep-talking.
+3.12 am: Brain buzzing with the drone design idea. If I stay up now I can solder the prototype before school. Mum will flip if she sees the iron on the bench.
+
+2. Parent email to Year-Level Co-ordinator : 4 September
+Sam's sleeping pattern is upside-down: catnaps after school then tinkers in the garage till early morning. Says he is "working on the next big invention". Marks slipping from A's to C's. Won't shower some days, smells like solder flux. Claims neighbours "keep filming him through their dash cam". I thought this was teenage creativity, but the teacher says he mumbled to himself during English oral. Family history: my brother had "nervous breakdowns" at uni, eventually diagnosed bipolar. Sam tried weed once at a party in July : claims it "made thoughts louder" so he stopped.
+
+3. Physics teacher observation : Term 3 report
+ Lab work alternates between brilliant bursts (built an amplifier from scrap) and complete withdrawal (stares at oscilloscope for 20 minutes).
+ Spoke rapidly and off-topic about "electromagnetic surveillance" then laughed to himself.
+ Safety concern: left Bunsen burner lit, said the hissing sound was "comforting".
+      
+4. School counsellor intake note : 14 September
+Presents wearing hoodie despite 28 °C. Minimal eye contact; speech quiet but occasionally speeds up when describing "signals" hidden in LED flicker rates. States "people online talk in codes : you just have to notice". Denies suicidal intent but admits "sometimes wonder if I'm still the original Sam". Reports rare "energy spikes" where ideas flow so fast "hands can't keep up". Appetite patchy; weight stable. No alcohol or ongoing cannabis use.
+
+5. GP timeline (key points)
+ June : Review for persistent tension headaches. Vital signs normal. Sleep 4-5 h/night.
+ August : Mother concerned about hygiene, isolation, talking to himself. GP administers K-10 (score = 36) and SANS (elevated negative-symptom domain). Referred to early psychosis service; appointment booked for October.
+ Lab tests: CBC, TFTs, urine drug screen : all within normal limits.
+      
+6. Text message exchange with close friend "Cooper" : 19 September
+Cooper: Bro you missed footy prac again. Coach is spewin.
+Sam: Field's bugged mate. Linesmen carry comms packs. Not safe.
+Cooper: It's just walkie-talkies. Everyone uses them.
+Sam: Exactly.
+
+7. Chemistry practical rubric : teacher annotation
+"Failed to record titration volumes : said numbers keep rearranging themselves on the page. Asked to restart three times, then abandoned."
+
+8. Local police incident log : 1 October
+Patrol called at 01 37 h by neighbour complaining about `metallic whirring'. Officers found Sam operating homemade quad-copter with camera removed. He alleged he was "jamming illicit frequencies". No charges; advised to cease late-night testing.
+
+
+


### PR DESCRIPTION
## Summary
- extract each scenario from the collated document and save as standalone `.txt` files

## Testing
- `docx2txt 'Diagnosis scenarios/Year 10 Diagnosis Scenarios - Collated Documents.docx' /tmp/doc.txt`


------
https://chatgpt.com/codex/tasks/task_e_684f6bb8c3b08327b2ea3ab24bb237d6