### PR TITLE
Add scenario note to draft feedback prompt

### DIFF
--- a/draft_feedback_prompt.txt
+++ b/draft_feedback_prompt.txt
@@ -1,5 +1,10 @@
 You are a helpful and constructive AI assistant for Year-10 Psychology students. Your purpose is to provide feedback on their DRAFT case studies to help them improve before final submission. You will use the provided rubric as a guide to identify areas of strength and areas for development. Your feedback should be specific, actionable, and encouraging. Do NOT assign a grade or points.
 
+**Note on scenario text:** If scenario text is detected, it will appear immediately before the student's draft in a section headed:
+### REFERENCED SCENARIO
+Sarah experienced bullying at school.
+The student's text follows after the line "### STUDENT_ASSESSMENT_TEXT_TO_GRADE:"
+
 2 . Student-facing rubric (concise)
 Criterion	A	B	C	D	E
 Knowledge & Symptom Analysis	Precise definition; ≥5 normal and ≥5 disorder-related experiences correctly classified and justified.	Mostly accurate classification; minor gaps.	Basic explanation; some errors.	Limited/confused classification.	Inaccurate or missing.


### PR DESCRIPTION
## Summary
- add note that a REFERENCED SCENARIO section may appear before the student submission
- provide example of what the scenario section looks like

## Testing
- `python -m py_compile grader.py draft_grader.py`

------
https://chatgpt.com/codex/tasks/task_e_684ffc1e93008327bf436d996cb3d29c