### PR TITLE
Unify heading for student text insertion

### DIFF
--- a/draft_feedback_prompt.txt
+++ b/draft_feedback_prompt.txt
@@ -287,5 +287,5 @@ This is a good start on your case study, and you've clearly put effort into seve
 *   **Treatment & Justification:** Link your chosen treatments more directly to specific symptoms identified earlier, and briefly explain why these are evidence-based for the diagnosed disorder.
 *   **Communication & Referencing:** Conduct a careful proofread for any language errors and ensure your APA/Harvard referencing (both in-text and list) is flawless and complete.
 
-### STUDENT_ASSESSMENT_TEXT_TO_GRADE:
+### STUDENT_SUBMISSION_TEXT_TO_GRADE:
 {{STUDENT_SUBMISSION_TEXT_HERE}}

--- a/draft_grader.py
+++ b/draft_grader.py
@@ -156,7 +156,7 @@ def construct_full_prompt(student_text, master_prompt_template, scenario_text=No
     placeholder = "{{STUDENT_SUBMISSION_TEXT_HERE}}"
     if placeholder not in master_prompt_template:
         logging.error(f"Placeholder '{placeholder}' not found in draft prompt template.")
-        return master_prompt_template + "\n\n### STUDENT_ASSESSMENT_TEXT_TO_GRADE:\n" + combined_text
+        return master_prompt_template + "\n\n### STUDENT_SUBMISSION_TEXT_TO_GRADE:\n" + combined_text
     return master_prompt_template.replace(placeholder, combined_text)
 
 

--- a/grader.py
+++ b/grader.py
@@ -123,7 +123,7 @@ def construct_full_prompt(student_text, master_prompt_template):
         # Fallback: append student text if placeholder is missing
         return (
             master_prompt_template
-            + "\n\n### STUDENT_ASSESSMENT_TEXT_TO_GRADE:\n"
+            + "\n\n### STUDENT_SUBMISSION_TEXT_TO_GRADE:\n"
             + student_text
         )
     return master_prompt_template.replace(

--- a/master_prompt.txt
+++ b/master_prompt.txt
@@ -266,5 +266,5 @@ assistant_grade:
     communication: {band: 2, points: 2}
   overall_grade: B
 
-### STUDENT_ASSESSMENT_TEXT_TO_GRADE:
+### STUDENT_SUBMISSION_TEXT_TO_GRADE:
 {{STUDENT_SUBMISSION_TEXT_HERE}}


### PR DESCRIPTION
## Summary
- standardize insertion heading to `STUDENT_SUBMISSION_TEXT_TO_GRADE` in both prompts
- update fallback strings in `grader.py` and `draft_grader.py` to match

## Testing
- `python -m py_compile grader.py draft_grader.py`

------
https://chatgpt.com/codex/tasks/task_e_6850010eabfc8327ab5dcfaa6304b85e