### PR TITLE
Improve draft feedback formatting

### DIFF
--- a/draft_grader.py
+++ b/draft_grader.py
@@ -196,17 +196,47 @@ def call_gemini_api(prompt_text, api_key):
             logging.error(f"Google API Error Message: {e.message}")
         return None
 
+def _add_formatted_run(paragraph, text):
+    """Adds text to a paragraph, interpreting **bold** markdown syntax."""
+    parts = re.split(r"(\*\*[^*]+\*\*)", text)
+    for part in parts:
+        if part.startswith("**") and part.endswith("**") and len(part) > 4:
+            run = paragraph.add_run(part[2:-2])
+            run.bold = True
+        else:
+            paragraph.add_run(part)
+
+
 def save_draft_feedback_to_docx(feedback_prose, output_filepath, student_identifier):
-    """Saves the AI-generated prose feedback directly into a DOCX file."""
+    """Saves the AI-generated prose feedback to a nicely formatted DOCX file."""
     try:
         doc = DocxDocument()
         doc.add_heading(f"Draft Feedback Report for: {student_identifier}", level=1)
-        
-        # Split the feedback prose by newlines and add as separate paragraphs
-        # This helps maintain some of the AI's formatting (like paragraph breaks)
-        for line in feedback_prose.splitlines():
-            doc.add_paragraph(line)
-            
+
+        bullet_styles = ["List Bullet", "List Bullet 2", "List Bullet 3"]
+
+        for raw_line in feedback_prose.splitlines():
+            line = raw_line.rstrip()
+            if not line.strip():
+                doc.add_paragraph()
+                continue
+
+            if line.startswith("**") and line.endswith("**") and len(line) > 4:
+                heading_text = line.strip("*")
+                doc.add_heading(heading_text, level=2)
+                continue
+
+            bullet_match = re.match(r"^(\s*)\*\s+(.*)", line)
+            if bullet_match:
+                indent, bullet_text = bullet_match.groups()
+                level = min(len(indent) // 4, 2)
+                para = doc.add_paragraph(style=bullet_styles[level])
+                _add_formatted_run(para, bullet_text.strip())
+                continue
+
+            para = doc.add_paragraph()
+            _add_formatted_run(para, line.strip())
+
         doc.save(output_filepath)
         logging.info(f"Draft feedback report saved to: {output_filepath}")
     except Exception as e:


### PR DESCRIPTION
## Summary
- format draft feedback DOCX using headings and bullet lists

## Testing
- `python -m py_compile draft_grader.py`
- `python draft_grader.py` *(fails: failed to connect to remote host)*

------
https://chatgpt.com/codex/tasks/task_e_68500f888f80832795bf2be08836819b