### PR TITLE
Remove unused word doc formatting imports

### DIFF
--- a/grader.py
+++ b/grader.py
@@ -4,8 +4,6 @@ import logging
 from dotenv import load_dotenv
 import google.generativeai as genai
 from docx import Document as DocxDocument  # To avoid clash with local 'Document'
-from docx.shared import Pt
-from docx.enum.text import WD_ALIGN_PARAGRAPH
 import PyPDF2
 import yaml  # PyYAML
 


### PR DESCRIPTION
## Summary
- clean up unused imports from `grader.py`

## Testing
- `pytest -q`
- `python -m py_compile grader.py`


------
https://chatgpt.com/codex/tasks/task_e_685892a742708327ab5137c2e949a8ec