### PR TITLE
Add grade review moderation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains Python scripts to generate automated grading reports an
 - `master_prompt.txt` – prompt template and rubric for the main grader.
 - `draft_feedback_prompt.txt` – prompt for draft feedback.
 - `feedback_review_prompt.txt` – prompt used to check the AI feedback against the student's submission.
+- `grade_review_prompt.txt` – prompt used to double-check the fairness of the final grade.
 - `grading_process.log` and `draft_grading_process.log` – example log files created by the scripts.
 - `venv/` – Python virtual environment containing all dependencies (committed for portability).
 
@@ -45,6 +46,7 @@ Run the main grader:
 ```bash
 python grader.py
 ```
+This script now performs an additional moderation pass to check that the assigned grade is fair. Any concerns are saved as a `_grade_review.txt` file next to the final DOCX report.
 
 For draft feedback instead of a final grade:
 
@@ -69,4 +71,4 @@ The overall grade in each report is derived from the rubric points returned by t
 - The repository currently includes a Windows-based `venv` directory which can be removed if you prefer to create your own environment.
 - There are no automated tests.
 - Each run of `draft_grader.py` also outputs a `_feedback_review.txt` file summarising any inaccuracies in the AI feedback or areas already addressed in the submission.
-- After running `grader.py` a `grading_summary.csv` file is written in `output_feedback/` containing each student's total points and final grade.
+- Running `grader.py` performs a second pass to verify the grading. The result is saved as a `_grade_review.txt` file alongside each report, and a `grading_summary.csv` file summarises total points and grades.

--- a/grade_review_prompt.txt
+++ b/grade_review_prompt.txt
@@ -1,0 +1,10 @@
+You are an independent moderator tasked with verifying the fairness of AI-generated grades for a Year-10 Psychology case-study task. Review the student's submission alongside the AI's YAML grade breakdown. Identify any criteria that appear to be graded too harshly or too leniently based on the rubric. Quote short excerpts from the student's text that support your judgement. If the grading seems appropriate, simply state "No issues found." Respond in a concise list of bullet points.
+
+### STUDENT_SUBMISSION
+{{STUDENT_SUBMISSION_TEXT_HERE}}
+
+### AI_GRADE_YAML
+{{AI_GRADE_YAML_HERE}}
+
+### REVIEW_OUTPUT
+Summarise any potential grading issues. If none, write "No issues found."


### PR DESCRIPTION
## Summary
- add `grade_review_prompt.txt` for moderation of grading fairness
- update `README` with new prompt and review process
- update `grader.py` to run a second pass using the new prompt and save `_grade_review.txt`

## Testing
- `python -m py_compile grader.py draft_grader.py`

------
https://chatgpt.com/codex/tasks/task_e_68589e3c7bcc8327ad61fa4cf95da207