### PR TITLE
Display AI and computed grades in reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Each script processes all files in `input_assessments/` and writes DOCX reports 
 
 The overall grade in each report is derived from the rubric points returned by the AI. All points from `assistant_grade.breakdown` are summed (out of 25). Scores of **20–25** receive an **A**, **15–19** a **B** and **12–14** a **C**. Scores below 12 fall back to the original band mapping for **D** or **E**.
 
+Each DOCX report lists the grade suggested by the AI (`assistant_grade.overall_grade`) alongside the grade calculated from the rubric totals. If the two differ, the final grade shown is the one based on the rubric points and a short note explains that the grade was adjusted accordingly.
+
 ## Notes
 
 - PDF text extraction uses `PyPDF2`; encrypted or malformed PDFs may fail.

--- a/grader.py
+++ b/grader.py
@@ -386,9 +386,10 @@ def format_feedback_as_docx(
         # Overall Grade and Points
         grade_info = yaml_data.get("assistant_grade", {})
         breakdown = grade_info.get("breakdown", {})
-        overall_grade = compute_overall_grade(breakdown)
-        if override_grade:
-            overall_grade = override_grade
+
+        ai_overall_grade = grade_info.get("overall_grade")
+        computed_grade = compute_overall_grade(breakdown)
+        final_grade = override_grade if override_grade else computed_grade
         try:
             total_points = sum(int(item.get("points", 0)) for item in breakdown.values())
         except Exception:
@@ -396,7 +397,11 @@ def format_feedback_as_docx(
         max_total_points = 25
 
         doc.add_heading("Overall Assessment", level=2)
-        doc.add_paragraph(f"Overall Grade: {overall_grade}")
+        if ai_overall_grade:
+            doc.add_paragraph(f"AI Reported Grade: {ai_overall_grade}")
+        doc.add_paragraph(f"Grade Based on Points: {final_grade}")
+        if ai_overall_grade and ai_overall_grade != final_grade:
+            doc.add_paragraph("Note: Grade adjusted based on rubric totals.")
         doc.add_paragraph(f"Total Points: {total_points} / {max_total_points}")
         doc.add_paragraph()  # Spacer
 


### PR DESCRIPTION
## Summary
- show both AI-provided grade and computed grade when creating DOCX reports
- note when the grade has been adjusted
- document new behaviour in the README

## Testing
- `python -m py_compile grader.py`

------
https://chatgpt.com/codex/tasks/task_e_6858aba97e8c8327838e8e58a208774d