### PR TITLE
Refactor grader logic and prompts

### DIFF
--- a/grade_review_prompt.txt
+++ b/grade_review_prompt.txt
@@ -1,10 +1,20 @@
-You are an independent moderator tasked with verifying the fairness of AI-generated grades for a Year-10 Psychology case-study task. Review the student's submission alongside the AI's YAML grade breakdown. Identify any criteria that appear to be graded too harshly or too leniently based on the rubric. Quote short excerpts from the student's text that support your judgement. If the grading seems appropriate, simply state "No issues found." Respond in a concise list of bullet points. If you feel the overall grade should change, add a line starting with **"Recommended grade:"** followed by the letter grade you believe is accurate.
+You are an independent moderator tasked with verifying the fairness of AI-generated grades. Review the student's submission alongside the AI's YAML grade breakdown.
+If you find no issues, respond with "No issues found."
+If you identify issues, provide your feedback as a list.
+For each criterion that needs a band change, add a line with ADJUSTMENT: [criterion_id] -> [new_band_number].
+If the overall grade should change, add a final line: RECOMMENDED_GRADE: [A-E]
 
-### STUDENT_SUBMISSION
+EXAMPLE OUTPUT
+The 'treatment' section seems graded too harshly. The student proposed CBTp which is evidence-based. Evidence: "My calculated treatment approach for Sam D is a combination of CBTp..."
+ADJUSTMENT: treatment -> 4
+The 'communication' band is too high. The submission is over the word limit.
+ADJUSTMENT: communication -> 2
+RECOMMENDED_GRADE: B
+
+STUDENT_SUBMISSION
 {{STUDENT_SUBMISSION_TEXT_HERE}}
 
-### AI_GRADE_YAML
+AI_GRADE_YAML
 {{AI_GRADE_YAML_HERE}}
 
-### REVIEW_OUTPUT
-Summarise any potential grading issues. If none, write "No issues found."
+YOUR REVIEW OUTPUT:

--- a/master_prompt.txt
+++ b/master_prompt.txt
@@ -1,271 +1,53 @@
 ### Student-Facing Rubric (Concise)
-Criterion	A	B	C	D	E
-Knowledge & Symptom Analysis	Precise definition; ≥5 normal and ≥5 disorder-related experiences correctly classified and justified.	Mostly accurate classification; minor gaps.	Basic explanation; some errors.	Limited/confused classification.	Inaccurate or missing.
-B-P-S Factors	Biological, psychological and social factors clearly linked and interacting.	Most factors linked; minor gaps.	Factors listed; weak links.	Few factors; unclear links.	Incorrect / missing.
-Diagnostic Reasoning (primary)	DSM-5 criteria mapped, duration justified; diagnosis airtight.	Accurate, minor omissions.	Plausible but partial mapping.	Weak or incorrect diagnosis.	Absent.
-Differential Diagnosis	Plausible secondary disorder; clear comparison.	Good secondary, minor gaps.	Named but weak comparison.	Inappropriate / minimal.	Absent.
-Treatment & Justification	Evidence-based therapy/meds; detailed links to symptoms.	Appropriate; good links.	Suitable; generic links.	Partly unsuitable or vague.	Absent/incorrect.
-Communication & Referencing	Clear structure, fluent writing, correct APA/Harvard, 0–1 errors, 800–1200 w.	Mostly clear; ≤3 errors.	Adequate; several errors; minor word-count drift.	Disorganised; frequent errors.	Ineffective or plagiarised.
-
-
+Criterion       A       B       C       D       E
+Knowledge & Symptom Analysis    Precise definition; ≥5 normal and ≥5 disorder-related experiences correctly classified and justified.   Mostly accurate classification; minor gaps.     Basic explanation; some errors.  Limited/confused classification.        Inaccurate or missing.
+B-P-S Factors   Biological, psychological and social factors clearly linked and interacting.    Most factors linked; minor gaps.        Factors listed; weak links.     Few factors; unclear links.     Incorrect / missing.
+Diagnostic Reasoning (primary)  DSM-5 criteria mapped, duration justified; diagnosis airtight.  Accurate, minor omissions.      Plausible but partial mapping. Weak or incorrect diagnosis.     Absent.
+Differential Diagnosis  Plausible secondary disorder; clear comparison. Good secondary, minor gaps.     Named but weak comparison.      Inappropriate / minimalAbsent.
+Treatment & Justification       Evidence-based therapy/meds; detailed links to symptoms.        Appropriate; good links.        Suitable; generic links.       Partly unsuitable or vague.      Absent/incorrect.
+Communication & Referencing     Clear structure, fluent writing, correct APA/Harvard, 0–1 errors, 800–1200 w.   Mostly clear; ≤3 errors.        Adequate; several errors; minor word-count drift.       Disorganised; frequent errors.  Ineffective or plagiarised.
 
 ### SYSTEM
-You are a strict marker for Year-10 Psychology case-study tasks.
-
-### RUBRIC_JSON
-{
-  "rubric_name": "Year-10 Case-Study Diagnostic Task",
-  "total_points": 30,
-  "word_count": { "min": 750, "max": 1250, "penalty_band": 2 },
-  "criteria": [
-    {
-      "id": "symptom_analysis",
-      "name": "Knowledge & Symptom Analysis",
-      "weight": 5,
-      "bands": {
-        "5": "Explains psychological disorder concept precisely; valid justification/explanation of everyday vs valid justification/explanation pathological experiences categorised and explicitly linked to impairment.",
-        "4": "Sound explanation; most symptoms correctly split; minor omissions.",
-        "3": "Adequate explanation; several mis-categorisations or weak links.",
-        "2": "Limited or confused explanation; many errors.",
-        "1": "Little or no accurate content."
-      },
-      "anchors": {
-        "5": [
-          "defines psychological disorder",
-          "impairment OR functional",
-          "≥5 normal symptoms",
-          "≥5 pathological symptoms"
-        ],
-        "4": [
-          "defines psychological disorder",
-          "≥4 normal",
-          "≥4 pathological"
-        ],
-        "3": [
-          "≥3 normal",
-          "≥3 pathological"
-        ],
-        "2": [
-          "≥2 total symptoms"
-        ],
-        "1": []
-      }
-    },
-    {
-      "id": "bps_factors",
-      "name": "Biological, Psychological & Social Factors",
-      "weight": 5,
-      "bands": {
-        "5": "Identifies and inter-links at least two clear factors in any three domains; explains interaction coherently.",
-        "4": "Identifies most factors; interaction explained with minor gaps.",
-        "3": "Lists factors with superficial links.",
-        "2": "Few factors; little interaction.",
-        "1": "Incorrect or missing factors."
-      },
-      "anchors": {
-        "5": ["biological", "psychological", "social", "interact"],
-        "4": ["biological", "psychological", "social"],
-        "3": ["two domains"],
-        "2": ["one domain"],
-        "1": []
-      }
-    },
-    {
-      "id": "diagnostic_primary",
-      "name": "Primary Diagnosis Accuracy & Justification",
-      "weight": 5,
-      "bands": {
-        "5": "Maps each DSM-5 criterion to evidence; cites duration; valid justification.",
-        "4": "Accurate diagnosis; reasonable justification, minor omissions.",
-        "3": "Plausible but incomplete mapping or missing duration detail.",
-        "2": "Diagnosis weakly supported or partially incorrect.",
-        "1": "Incorrect or absent diagnosis."
-      },
-      "anchors": {
-        "5": ["DSM-5", "duration", "all criteria"],
-        "4": ["DSM-5", "most criteria"],
-        "3": ["DSM-5 OR duration"],
-        "2": ["diagnosis stated"],
-        "1": []
-      }
-    },
-    {
-      "id": "diagnostic_diff",
-      "name": "Differential Diagnosis Reasoning",
-      "weight": 5,
-      "bands": {
-        "5": "Selects plausible secondary disorder; compares and rules out with evidence.",
-        "4": "Secondary disorder appropriate; comparison mostly sound.",
-        "3": "Secondary named; limited comparison.",
-        "2": "Inappropriate or weak secondary; little reasoning.",
-        "1": "Missing."
-      },
-      "anchors": {
-        "5": ["secondary", "rule out", "because"],
-        "4": ["secondary", "overlap"],
-        "3": ["secondary"],
-        "2": [],
-        "1": []
-      }
-    },
-    {
-      "id": "treatment",
-      "name": "Treatment Selection & Justification",
-      "weight": 5,
-      "bands": {
-        "5": "Evidence-based treatment(s); detailed links to specific symptoms; mentions delivery & meds where relevant.",
-        "4": "Appropriate treatment; clear links; minor detail gaps.",
-        "3": "Generally suitable; explanation generic.",
-        "2": "Partly unsuitable or poorly explained.",
-        "1": "Absent or inaccurate."
-      },
-      "anchors": {
-        "5": ["guideline", "link", "symptom"],
-        "4": ["appropriate", "explain"],
-        "3": ["treatment"],
-        "2": [],
-        "1": []
-      }
-    },
-    {
-      "id": "communication",
-      "name": "Communication & Referencing",
-      "weight": 5,
-      "bands": {
-        "5": "Logical structure, fluent academic style; 0-3 language errors; APA/Harvard refs flawless; within word range.",
-        "4": "Clear structure; ≤4 errors; referencing minor issues.",
-        "3": "Adequate organisation; several errors; referencing flawed; slight word-count drift.",
-        "2": "Disorganised; frequent errors; poor referencing; major word-count breach.",
-        "1": "Ineffective communication or plagiarism."
-      },
-      "anchors": {
-        "5": ["reference list", "in-text"],
-        "4": ["reference"],
-        "3": ["APA", "Harvard"],
-        "2": [],
-        "1": []
-      }
-    }
-  ],
-  "rules": [
-    {
-      "name": "Word-count ceiling",
-      "condition": "word_count < 750 OR word_count > 1250",
-      "action": "set_band",
-      "target": "communication",
-      "band": 2
-    },
-    {
-      "name": "Primary diagnosis incorrect",
-      "condition": "diagnostic_primary_band < 3",
-      "action": "cap",
-      "targets": { "treatment": 3 }
-    }
-  ],
-  "grading_scale": { "5": "A", "4": "B", "3": "C", "2": "D", "1": "E" }
-}
-
-### EXAMPLE_HIGH
-Section 1 – Knowledge of Disorders and Symptoms
-1.1 What is a psychological disorder?
-A psychological disorder is a clinically significant pattern of cognition, emotion regulation or behaviour that reflects dysfunction in psychological, biological or developmental processes and produces distress or impairment (American Psychiatric Association [APA], 2013).
-1.2 Symptom categorisation
-Everyday / low-impact experiences (no major impairment)	Disorder-linked symptoms (cause impairment)
-Sneaker reselling as a side hobby	Repeated deceit for profit (hacking canteen, sneaker scam)
-Ambition to sit courtside at basketball	Persistent grandiose self-image (“own the class”, “front row autograph”)
-Enjoyment of coding	Trespass and property damage during “urban exploration”
-Competitive rugby play	Physical aggression (elbowing winger post-whistle)
-Occasional late-night planning	Consistent lack of remorse (“teachers are clueless”, “prove it”)
-Why?
-The left column activities are legal or socially typical and do not substantially limit Callum’s functioning. The right column behaviours breach others’ rights or school rules, trigger suspensions, legal cautions and peer alienation, demonstrating functional impairment (APA, 2013).
-1.3 Biological, Psychological & Social (B-P-S) factors
-Biological – Callum’s impulsivity and sensation-seeking may be partly heritable (father’s juvenile theft, possible low serotonergic regulation). Mild head injury (concussion) can further lower inhibition thresholds.
-Psychological – Core entitlement schema (“system is there to beat”), externalisation of blame, and thrill-seeking reinforce antisocial acts. Absence of guilt blocks corrective learning.
-Social – Permissive parenting (“we covered the damages”), peer reinforcement for risk videos, and online clout culture normalise rule-breaking. These social contingencies interact with impulsive temperament to stabilise the antisocial pattern.
-________________________________________
-Section 2 – Applying Diagnostic Criteria
-2.1 Core symptoms used for diagnosis
-•	Deceitfulness for personal gain (canteen hack, tool theft, sneaker scalping).
-•	Impulsivity and failure to plan ahead (late-night street races, helmet-free crash).
-•	Irritability and aggressiveness (punch-up, rugby elbow).
-•	Reckless disregard for safety of self/others (angle-grinder guard removal, motorbike races).
-•	Consistent lack of remorse (laughs when confronted, “prove it”).
-•	Conduct problems before age 15 (school hacking, theft).
-2.2 Duration
-Conduct-like behaviours are documented across two academic years (suspension “last term”, current warehouse trespass). This exceeds the 12-month minimum for Antisocial Personality Disorder and satisfies “pervasive pattern” (APA, 2013).
-2.3 Most likely disorder – Antisocial Personality Disorder (provisional)
-Callum meets ≥ 3 DSM-5 criteria for ASPD, with evidence across school, home and community. Age criterion (≥ 18) is met in six months; DSM allows provisional diagnosis when conduct disorder traits persist into late adolescence.
-2.4 Second most likely disorder – Narcissistic Personality Disorder
-Grandiosity, need for admiration and exploitation suggest NPD, but antisocial violations dominate the presentation and drive impairment (legal trouble > ego injury). NPD therefore ranks second.
-________________________________________
-Section 3 – Treatment Plan
-3.1 Approach – Cognitive Behavioural Therapy with Offence-Focused Modules (CBT-A) augmented by Multisystemic Therapy (MST).
-3.2 Administration
-•	CBT-A: Weekly 60-min individual sessions for 20 weeks targeting cognitive distortions (“winners deserve the prize”), anger cues and problem-solving. Includes victim-empathy role-plays.
-•	MST: Therapist works with family and school for 4–6 months, setting clear contingencies (immediate loss of motorbike keys after infractions) and coaching parents on consistent limits.
-•	School adds a behaviour contract plus token reward for pro-social acts; legal liaison monitors compliance. Medication not indicated unless future comorbid ADHD/irritability emerges.
-3.3 Symptom reduction rationale
-CBT-A restructures entitlement beliefs and builds future-orientation, directly addressing deceitfulness and impulsivity. Anger-management modules decrease aggression in rugby and peer disputes. MST aligns home and school responses, reducing reinforcement of thrill-seeking. Empathy training plus real-life restitution targets his remorse deficit.
-________________________________________
-Reference List
-American Psychiatric Association. (2013). Diagnostic and statistical manual of mental disorders (5th ed.).
-
-### EXAMPLE_LOW
-Section 1
-Definition
-A psychological disorder is when feelings or behaviour get so extreme they bother the person and mess with normal life (APA, 2013).
-Normal vs non-normal
-•	Normal things: likes coding; selling shoes; wants to be rich; plays rugby; stays up late sometimes.
-•	Not normal: keeps hacking, steals tools, bashes kids, races bikes without helmet, brags no remorse.
-Reasoning – Selling shoes is legal, but hacking and stealing are crimes and get him suspended, so they affect functioning.
-B/P/S
-•	Bio – Dad had trouble as a teen, maybe genes for risk-taking.
-•	Psy – Thinks rules don’t apply, high sensation seeking.
-•	Social – Friends hype him up online, parents cover damages so no consequences.
-________________________________________
-Section 2
-Core symptoms
-Lies for profit, aggressive fights, risky stunts, little guilt.
-Duration
-Stuff happened last term and now, at least 6 months.
-Main diagnosis
-Antisocial Personality Disorder (provisional) because he breaks rules, hurts people and doesn’t care.
-Second choice
-Narcissistic Personality because he’s full of himself, but antisocial fits better. Not schizophrenia etc.
-________________________________________
-Section 3
-Treatment
-Do Cognitive Behaviour Therapy once a week to learn empathy and better choices. Family should back this up with rewards for good behaviour. Might need meds later if he gets angry all the time.
-How it helps – CBT shows him the damage he causes and gives thinking steps before acting, so fewer fights and hacking.
-________________________________________
-Reference
-APA. (2013).
+You are a strict marker for Year-10 Psychology case-study tasks. You will analyze the student's submission against a detailed rubric. Your task is to assess each criterion, assign a band from 1 to 5, and provide a concise rationale for your decision.
 
 ### INSTRUCTIONS
-1. Extract evidence from the student script.
-2. For each criterion:
-   a. Check anchor phrases.
-   b. Select the highest band whose anchors are fully met.
-   c. Apply ‘rules’ (word-count, wrong diagnosis caps).
-   d. In the `rationale` briefly state what was missing and give a short example of wording that would reach the next highest band so the student knows how to improve.
-3. Output **only** the YAML below inside a fenced code block (` ```yaml ... ``` `):
+1.  Read the student's submission carefully.
+2.  For each of the six grading criteria, determine the most appropriate band (1-5) based on the rubric.
+3.  For each criterion, provide:
+    - `criterion`: The unique ID for the criterion (e.g., `symptom_analysis`).
+    - `band`: The integer band you have assigned (1-5).
+    - `evidence`: One or two direct quotes from the submission that best justify your assigned band.
+    - `rationale`: A brief explanation of why this band was chosen. State what the student did well and what was missing for the next band. **IMPORTANT: If your rationale includes double quotes, you MUST escape them with a backslash, like this: \"example\"**.
+4.  Output **only** the YAML below inside a fenced code block (` ```yaml ... ``` `). Do not include any other text, greetings, or explanations outside the YAML block.
 
+### EXAMPLE OUTPUT FORMAT
+```yaml
 assistant_reasons:
   - criterion: symptom_analysis
-    evidence: "...quoted line..."
+    evidence: "A psychological disorder is a clinically significant pattern of cognition, emotion regulation or behaviour that reflects dysfunction..."
     band: 5
-    rationale: "..."
-  - ...
-assistant_grade:
-  total_points: 22
-  breakdown:
-    symptom_analysis: {band: 5, points: 5}
-    bps_factors: {band: 4, points: 4}
-    diagnostic_primary: {band: 4, points: 4}
-    diagnostic_diff: {band: 3, points: 3}
-    treatment: {band: 4, points: 4}
-    communication: {band: 2, points: 2}
-  overall_grade: B
+    rationale: "The student precisely defined the term and correctly classified over 5 normal and pathological experiences with clear justification, meeting all top-band anchors."
+  - criterion: bps_factors
+    evidence: "These social contingencies interact with impulsive temperament to stabilise the antisocial pattern."
+    band: 5
+    rationale: "Excellent work linking all three B-P-S factors and explaining their interaction, rather than just listing them."
+  - criterion: diagnostic_primary
+    evidence: "Callum meets ≥ 3 DSM-5 criteria for ASPD, with evidence across school, home and community."
+    band: 4
+    rationale: "Accurate diagnosis and good justification. To reach the top band, the student needed to more explicitly map *all* relevant DSM-5 criteria to evidence from the text."
+  - criterion: diagnostic_diff
+    evidence: "NPD therefore ranks second."
+    band: 3
+    rationale: "A plausible secondary disorder was named, but the comparison was limited. A stronger response would have detailed why ASPD is a better fit than NPD, using evidence to rule out NPD."
+  - criterion: treatment
+    evidence: "CBT-A restructures entitlement beliefs and builds future-orientation, directly addressing deceitfulness and impulsivity."
+    band: 5
+    rationale: "A detailed, evidence-based plan is provided with clear links between the treatment components and the specific symptoms they target."
+  - criterion: communication
+    evidence: "The entire submission."
+    band: 4
+    rationale: "The work is well-structured and mostly clear, with only minor referencing issues. Meets the 'B' grade criteria for communication."
+```
 
 ### STUDENT_SUBMISSION_TEXT_TO_GRADE:
 {{STUDENT_SUBMISSION_TEXT_HERE}}

--- a/rubric.yml
+++ b/rubric.yml
@@ -1,0 +1,41 @@
+rubric_name: "Year-10 Case-Study Diagnostic Task"
+total_points_possible: 25
+word_count:
+  min: 750
+  max: 1250
+criteria:
+  symptom_analysis:
+    name: "Knowledge & Symptom Analysis"
+    max_points: 5
+  bps_factors:
+    name: "Biological, Psychological & Social Factors"
+    max_points: 4
+  diagnostic_primary:
+    name: "Primary Diagnosis Accuracy & Justification"
+    max_points: 4
+  diagnostic_diff:
+    name: "Differential Diagnosis Reasoning"
+    max_points: 4
+  treatment:
+    name: "Treatment Selection & Justification"
+    max_points: 5
+  communication:
+    name: "Communication & Referencing"
+    max_points: 3
+rules:
+  - name: "Word-count ceiling"
+    condition: "word_count < 750 or word_count > 1250"
+    action: "set_band"
+    target: "communication"
+    band: 2
+  - name: "Primary diagnosis incorrect"
+    condition: "diagnostic_primary_band < 3"
+    action: "cap_points"
+    target: "treatment"
+    points: 3
+grade_bands:
+  A: 20
+  B: 15
+  C: 12
+  D_ratio: 0.4
+  E_ratio: 0.2


### PR DESCRIPTION
## Summary
- centralize rubric in new `rubric.yml`
- simplify grading prompts and review prompts
- load rubric and compute grades in `grader.py`
- apply rubric rules deterministically and use pathlib
- parse adjustment lines with regex

## Testing
- `python -m py_compile grader.py`


------
https://chatgpt.com/codex/tasks/task_e_6858e66fe4f883278cf5cbd4b15df29f