### PR TITLE
Align rubric with 30‑point grading scale

### DIFF
--- a/rubric.yml
+++ b/rubric.yml
@@ -1,5 +1,5 @@
 rubric_name: "Year-10 Case-Study Diagnostic Task"
-total_points_possible: 25
+total_points_possible: 30
 word_count:
   min: 750
   max: 1250
@@ -9,19 +9,19 @@ criteria:
     max_points: 5
   bps_factors:
     name: "Biological, Psychological & Social Factors"
-    max_points: 4
+    max_points: 5
   diagnostic_primary:
     name: "Primary Diagnosis Accuracy & Justification"
-    max_points: 4
+    max_points: 5
   diagnostic_diff:
     name: "Differential Diagnosis Reasoning"
-    max_points: 4
+    max_points: 5
   treatment:
     name: "Treatment Selection & Justification"
     max_points: 5
   communication:
     name: "Communication & Referencing"
-    max_points: 3
+    max_points: 5
 rules:
   - name: "Word-count ceiling"
     condition: "word_count < 750 or word_count > 1250"
@@ -34,8 +34,8 @@ rules:
     target: "treatment"
     points: 3
 grade_bands:
-  A: 20
-  B: 15
-  C: 12
+  A: 24
+  B: 18
+  C: 14
   D_ratio: 0.4
   E_ratio: 0.2


### PR DESCRIPTION
## Summary
- raise total points to 30 in `rubric.yml`
- allocate 5 points each for BPS factors, primary diagnosis, differential diagnosis, and communication
- adjust grade bands to A:24, B:18, C:14

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f1a1c49083278cbbb96d098b6fe6