### PR TITLE
Add Streamlit web interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,54 @@
+import streamlit as st
+import pandas as pd
+from pathlib import Path
+
+from grader import run_grading_process, INPUT_FOLDER, OUTPUT_FOLDER, SUMMARY_FILE
+
+st.title("AI Student Assessment Grader")
+
+uploaded_files = st.file_uploader(
+    "Upload student assignments (.docx or .pdf)",
+    type=["docx", "pdf"],
+    accept_multiple_files=True,
+)
+
+if "run_complete" not in st.session_state:
+    st.session_state["run_complete"] = False
+
+if st.button("Run Grading"):
+    if uploaded_files:
+        INPUT_FOLDER.mkdir(exist_ok=True)
+        for file in uploaded_files:
+            save_path = INPUT_FOLDER / file.name
+            with open(save_path, "wb") as f:
+                f.write(file.getbuffer())
+    with st.spinner("Grading in progress..."):
+        run_grading_process()
+    st.success("Grading complete!")
+    st.session_state["run_complete"] = True
+
+if st.session_state.get("run_complete"):
+    summary_path = OUTPUT_FOLDER / SUMMARY_FILE
+    if summary_path.exists():
+        st.subheader("Grading Summary")
+        df = pd.read_csv(summary_path)
+        st.dataframe(df)
+        with open(summary_path, "rb") as f:
+            st.download_button(
+                "Download Summary CSV",
+                data=f,
+                file_name=SUMMARY_FILE,
+                mime="text/csv",
+            )
+
+    st.subheader("Feedback Reports")
+    for report_path in sorted(OUTPUT_FOLDER.glob("*_graded.docx")):
+        with open(report_path, "rb") as f:
+            st.download_button(
+                label=f"Download {report_path.name}",
+                data=f,
+                file_name=report_path.name,
+                mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                key=report_path.name,
+            )
+

--- a/grader.py
+++ b/grader.py
@@ -559,7 +559,7 @@ def format_feedback_as_docx(
 
 
 # --- Main Processing Logic ---
-def main():
+def run_grading_process():
     logging.info("Starting AI Student Assessment Grader...")
     try:
         api_key = load_api_key()
@@ -727,4 +727,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    run_grading_process()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-python-dotenv
+dotenv-python
 google-generativeai
 python-docx
 PyPDF2
 PyYAML
+streamlit
+pandas


### PR DESCRIPTION
## Summary
- provide Streamlit-based `app.py`
- refactor `grader.py` so it can be imported as `run_grading_process`
- update dependencies and README

## Testing
- `python -m py_compile grader.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858f41f485c8327be0c05cee5cb8486