### PR TITLE
Fix rubric rule defaults

### DIFF
--- a/bigbraingrader.py
+++ b/bigbraingrader.py
@@ -357,7 +357,10 @@ def calculate_final_grade(bands_data, word_count, rubric_config):
         name = rule.get("name")
         try:
             condition = rule.get("condition", "")
-            local_vars = {f"{k}_band": bands.get(k) for k in bands}
+            local_vars = {
+                f"{cid}_band": int(bands.get(cid, 1))
+                for cid in criteria_cfg.keys()
+            }
             local_vars["word_count"] = word_count
             if eval(condition, {}, local_vars):
                 if rule.get("action") == "set_band":

--- a/grader.py
+++ b/grader.py
@@ -351,7 +351,10 @@ def calculate_final_grade(bands_data, word_count, rubric_config):
         name = rule.get("name")
         try:
             condition = rule.get("condition", "")
-            local_vars = {f"{k}_band": bands.get(k) for k in bands}
+            local_vars = {
+                f"{cid}_band": int(bands.get(cid, 1))
+                for cid in criteria_cfg.keys()
+            }
             local_vars["word_count"] = word_count
             if eval(condition, {}, local_vars):
                 if rule.get("action") == "set_band":

--- a/tests/test_calculate_final_grade.py
+++ b/tests/test_calculate_final_grade.py
@@ -1,0 +1,53 @@
+import logging
+import yaml
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import bigbraingrader
+import grader
+
+
+def test_rule_with_missing_band_bigbrain(caplog):
+    with open('rubric.yml') as f:
+        rubric_config = yaml.safe_load(f)
+
+    # bands missing 'diagnostic_primary'
+    bands = {
+        'symptom_analysis': 5,
+        'bps_factors': 5,
+        # omit diagnostic_primary intentionally
+        'diagnostic_diff': 4,
+        'treatment': 5,
+        'communication': 5,
+    }
+
+    caplog.set_level(logging.WARNING)
+    result = bigbraingrader.calculate_final_grade(bands, 1000, rubric_config)
+
+    # Rule should execute and cap treatment points to 3
+    assert result['breakdown']['treatment']['points'] == 3
+
+    # No warning about failed rule evaluation should be logged
+    assert "Failed to evaluate rule" not in caplog.text
+
+
+def test_rule_with_missing_band_grader(caplog):
+    with open('rubric.yml') as f:
+        rubric_config = yaml.safe_load(f)
+
+    bands = {
+        'symptom_analysis': 5,
+        'bps_factors': 5,
+        'diagnostic_diff': 4,
+        'treatment': 5,
+        'communication': 5,
+    }
+
+    caplog.set_level(logging.WARNING)
+    result = grader.calculate_final_grade(bands, 1000, rubric_config)
+
+    assert result['breakdown']['treatment']['points'] == 3
+
+    assert "Failed to evaluate rule" not in caplog.text


### PR DESCRIPTION
## Summary
- use full rubric criteria when calculating rule contexts
- add regression test for missing-band scenario
- apply the same logic to `grader.calculate_final_grade`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68596081b8f88327bc46db81da2ee3fb