### PR TITLE
Fix rule evaluation defaults

### DIFF
--- a/bigbraingrader.py
+++ b/bigbraingrader.py
@@ -357,7 +357,11 @@ def calculate_final_grade(bands_data, word_count, rubric_config):
         name = rule.get("name")
         try:
             condition = rule.get("condition", "")
-            local_vars = {f"{k}_band": bands.get(k) for k in bands}
+            # Provide all criteria variables for rule evaluation, defaulting
+            # missing bands to 1 so expressions never fail
+            local_vars = {
+                f"{cid}_band": int(bands.get(cid, 1)) for cid in criteria_cfg
+            }
             local_vars["word_count"] = word_count
             if eval(condition, {}, local_vars):
                 if rule.get("action") == "set_band":

--- a/tests/test_calculate_final_grade.py
+++ b/tests/test_calculate_final_grade.py
@@ -1,0 +1,45 @@
+import logging
+import sys
+from pathlib import Path
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub out optional dependencies required by bigbraingrader on import
+for name in ["google", "google.generativeai", "docx", "PyPDF2", "yaml"]:
+    if name not in sys.modules:
+        module = types.ModuleType(name)
+        if name == "docx":
+            module.Document = object
+        sys.modules[name] = module
+
+from bigbraingrader import calculate_final_grade
+
+
+def test_rule_execution_with_missing_band(caplog):
+    rubric = {
+        "criteria": {
+            "crit_a": {"max_points": 5},
+            "crit_b": {"max_points": 5},
+        },
+        "rules": [
+            {
+                "name": "default rule",
+                "condition": "crit_b_band == 1",
+                "action": "set_band",
+                "target": "crit_a",
+                "band": 5,
+            }
+        ],
+        "grade_bands": {"A": 10},
+        "total_points_possible": 10,
+    }
+
+    with caplog.at_level(logging.WARNING):
+        result = calculate_final_grade({"crit_a": 2}, 100, rubric)
+
+    # Ensure the rule executed and no evaluation warning was logged
+    assert not any(
+        "Failed to evaluate rule" in record.message for record in caplog.records
+    )
+    assert result["breakdown"]["crit_a"]["band"] == 5


### PR DESCRIPTION
## Summary
- make `calculate_final_grade` provide a 1 default for all rubric criteria when evaluating rules
- add regression test covering default band behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859edc99708832792f7d452d5117db0