### PR TITLE
Improve criterion key matching in grade calculator

### DIFF
--- a/bigbraingrader.py
+++ b/bigbraingrader.py
@@ -375,10 +375,21 @@ def calculate_final_grade(bands_data, word_count, rubric_config):
         except Exception:
             logging.warning(f"Failed to evaluate rule '{name}'.")
 
+    def _norm(key):
+        """Normalize keys for robust matching."""
+        return re.sub(r"\s+", "", str(key)).lower()
+
+    normalized_bands = {_norm(k): v for k, v in bands.items()}
+
     breakdown = {}
     total_points = 0
     for cid, cfg in criteria_cfg.items():
-        band = int(bands.get(cid, 1))
+        lookup_keys = [_norm(cid), _norm(cfg.get("name", ""))]
+        band = 1
+        for lk in lookup_keys:
+            if lk in normalized_bands:
+                band = int(normalized_bands[lk])
+                break
         max_points = int(cfg.get("max_points", band))
         points = min(band, max_points)
         breakdown[cid] = {"band": band, "points": points}

--- a/grader.py
+++ b/grader.py
@@ -369,10 +369,21 @@ def calculate_final_grade(bands_data, word_count, rubric_config):
         except Exception:
             logging.warning(f"Failed to evaluate rule '{name}'.")
 
+    def _norm(key):
+        """Normalize keys for robust matching."""
+        return re.sub(r"\s+", "", str(key)).lower()
+
+    normalized_bands = {_norm(k): v for k, v in bands.items()}
+
     breakdown = {}
     total_points = 0
     for cid, cfg in criteria_cfg.items():
-        band = int(bands.get(cid, 1))
+        lookup_keys = [_norm(cid), _norm(cfg.get("name", ""))]
+        band = 1
+        for lk in lookup_keys:
+            if lk in normalized_bands:
+                band = int(normalized_bands[lk])
+                break
         max_points = int(cfg.get("max_points", band))
         points = min(band, max_points)
         breakdown[cid] = {"band": band, "points": points}

--- a/tests/test_key_matching.py
+++ b/tests/test_key_matching.py
@@ -1,0 +1,22 @@
+import yaml
+import grader
+
+
+def test_case_whitespace_insensitive_lookup():
+    with open('rubric.yml') as f:
+        rubric_config = yaml.safe_load(f)
+
+    bands = {
+        'Symptom_Analysis ': 4,
+        '  COMMUNICATION  ': 5,
+        'Primary Diagnosis Accuracy & Justification': 3,
+        'bps_factors': 4,
+        'diagnostic_diff': 4,
+        'treatment': 4,
+    }
+
+    result = grader.calculate_final_grade(bands, 1000, rubric_config)
+
+    assert result['breakdown']['symptom_analysis']['band'] == 4
+    assert result['breakdown']['communication']['band'] == 5
+    assert result['breakdown']['diagnostic_primary']['band'] == 3


### PR DESCRIPTION
## Summary
- ensure grader can match bands using case/whitespace-insensitive IDs
- add matching fix to bigbraingrader to keep behaviour consistent
- test lookup with mixed-case and spaced keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f74e05ac8327858c13a7279ae7eb